### PR TITLE
Destroy flounder, when target is input having siblings

### DIFF
--- a/src/core/api.js
+++ b/src/core/api.js
@@ -96,10 +96,10 @@ const api = {
         let originalTarget      = this.originalTarget;
         let tagName             =  originalTarget.tagName;
 
-        refs.flounder.flounder  = originalTarget.flounder = this.target.flounder = null;
-
         if ( tagName === 'INPUT' || tagName === 'SELECT' )
         {
+            let target = originalTarget.nextElementSibling;
+
             if ( tagName === 'SELECT' )
             {
                 let firstOption = originalTarget[0];
@@ -108,9 +108,9 @@ const api = {
                 {
                     originalTarget.removeChild( firstOption );
                 }
+            } else if ( tagName === 'INPUT' ) {
+                target = refs.flounder.parentNode;
             }
-
-            let target = originalTarget.nextElementSibling;
 
             try
             {
@@ -136,6 +136,9 @@ const api = {
                 throw ' : this flounder may have already been removed';
             }
         }
+
+        refs.flounder.flounder  = originalTarget.flounder = this.target.flounder = null;
+
     },
 
 

--- a/tests/unit/flounderTest.js
+++ b/tests/unit/flounderTest.js
@@ -423,6 +423,43 @@ let tests = function( Flounder )
 
         flounder.destroy();
     } );
+
+
+    /**
+     * Destroy input when it has siblings.
+     * Flounder is added as last sibling.
+     * Flounder container should be remove properly on destroy.
+     */
+    QUnit.test( 'destroyInput', function( assert )
+    {
+        let data = [
+            {
+                text : "Item 1",
+                value : "item1"
+            },
+            {
+                text : "Item 2",
+                value : "item2"
+            }
+        ];
+
+        let container = document.createElement( 'div' ),
+            target = document.createElement( 'input' ),
+            someLabel = document.createElement( 'label' );
+
+        container.appendChild(target);
+        container.appendChild(someLabel);
+
+        document.body.appendChild( container );
+
+        let flounder    = ( new Flounder( target, { data : data } ) ),
+            flounderDomEl = flounder.refs.flounder.parentNode;
+
+        assert.ok( flounderDomEl.parentNode , 'flounder is in DOM' );
+        flounder.destroy();
+        assert.notOk( flounderDomEl.parentNode, 'flounder is NOT in DOM' +
+            ' anymore' );
+    } );
 };
 
 export default tests;


### PR DESCRIPTION
Now on destroy flounder removes next sibling of target. In this example target is input and label is going be removed on destroy.

![screenshot 2016-04-27 16 59 16](https://cloud.githubusercontent.com/assets/12760900/14859793/0b9eb074-0ca6-11e6-9d71-fa9a29cd7105.png)
