### PR TITLE
Select exact match when enter is pressed

### DIFF
--- a/src/core/events.js
+++ b/src/core/events.js
@@ -375,7 +375,7 @@ const events = {
 
             matches.forEach( el =>
             {
-                const index   = el.i;
+                const index   = el.d.index;
                 el          = refs.selectOptions[ index ];
 
                 if ( selected.indexOf( el ) === -1 )
@@ -384,9 +384,28 @@ const events = {
                 }
             } );
 
+            // If only one result is available, select that result.
+            // If more than one results, select one only on exact match.
+            let selectedIndex = -1;
             if ( res.length === 1 )
             {
-                const el = res[ 0 ];
+                selectedIndex = 0;
+            }
+            else if ( res.length > 1 )
+            {
+                for ( let i = 0; i < res.length ; i++ )
+                {
+                    if ( res[ i ].text.toUpperCase() === val.toUpperCase() )
+                    {
+                        selectedIndex = i;
+                        break;
+                    }
+                }
+            }
+
+            if ( selectedIndex != -1 )
+            {
+                const el = res[ selectedIndex ];
 
                 this.setByIndex( el.index, this.multiple );
 

--- a/test/unit/core/eventsTest.js
+++ b/test/unit/core/eventsTest.js
@@ -691,6 +691,33 @@ describe( 'checkEnterOnSearch', () =>
     } );
 
 
+    it( 'should select the option if there is an exact match', () =>
+    {
+        document.body.flounder = null;
+        const flounder    = new Flounder( document.body, {
+            data    : [ 'abcd', 'abcde', 'abc' ],
+            search  : true
+        } );
+
+        const refs        = flounder.refs;
+
+        sinon.stub( refs.search, 'focus', noop );
+
+        // Case insensitive match.
+        const e = {
+            target : {
+                value : 'Abc'
+            }
+        };
+
+        const res = flounder.checkEnterOnSearch( e, refs );
+
+        assert.equal( res.length, 2 );
+        assert.equal( flounder.getSelected().length, 1 );
+        assert.equal( flounder.getSelected()[ 0 ].value, 'abc' );
+    } );
+
+
     it( 'should only select the option if there is only one left', () =>
     {
         document.body.flounder = null;


### PR DESCRIPTION
When enter is pressed:
- If only one result is available, select that result.
- If more than one results, select one only on exact match.

Fixes: #128 

PS: There are some other failing tests. I think they are irrelevant with this commit. I will try to investigate them tomorrow.