### PR TITLE
Explicitly close dropdown list on clickSet #140

### DIFF
--- a/src/core/events.js
+++ b/src/core/events.js
@@ -646,7 +646,7 @@ const events = {
 
         if ( !this.programmaticClick )
         {
-            this.toggleList( e );
+            this.toggleList( e, 'close' );
         }
 
         this.programmaticClick = false;


### PR DESCRIPTION
Let’s get this small fix into 1.2.0 too