### PR TITLE
Issue 158 multi tag search

### DIFF
--- a/src/core/search.js
+++ b/src/core/search.js
@@ -144,37 +144,6 @@ export class Sole
 
 
     /**
-     * ## filterSelected
-     *
-     * helper function to filter selected options from search results
-     *
-     * @param {Object} res search result object
-     *
-     * @return {Boolean} data not in selected options
-     */
-    filterSelected( res )
-    {
-        if ( !res.d || !res.d.value )
-        {
-            return false;
-        }
-
-        if ( this.flounder.multipleTags )
-        {
-            for ( const o of this.flounder.getSelectedValues() )
-            {
-                if ( res.d.value === o )
-                {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
-
-    /**
      * ## getResultWeights
      *
      * after the data is prepared this is mapped through the data to get
@@ -275,7 +244,6 @@ export class Sole
             return false;
         }
 
-        ratedRes = ratedRes.filter( this.filterSelected.bind( this ) );
         ratedRes = ratedRes.filter( this.isItemAboveMinimum );
         ratedRes.sort( this.compareScoreCards );
 

--- a/test/unit/core/searchTest.js
+++ b/test/unit/core/searchTest.js
@@ -165,43 +165,6 @@ describe( 'Sole', () =>
 
 
     /**
-     * ## filterSelected
-     *
-     * helper function to filter selected options from search results
-     *
-     * @param {Object} res search result object
-     *
-     * @return {Boolean} data not in selected options
-     */
-    describe( 'filterSelected', () =>
-    {
-        it( 'should remove currently selected options from the results', () =>
-        {
-            const el = search.flounder.refs.select.children[ 1 ];
-
-            el.selected                     = true;
-            search.flounder.multipleTags    = true;
-
-            const resFalse = search.filterSelected( {
-                d : search.flounder.data[ 1 ]
-            } );
-
-            const resTrue = search.filterSelected( {
-                d : search.flounder.data[ 2 ]
-            } );
-
-            assert.equal( resTrue, true );
-            assert.equal( resFalse, false );
-
-            el.selected                     = false;
-            search.flounder.multipleTags    = false;
-
-        } );
-    } );
-
-
-
-    /**
      * ## getResultWeights
      *
      * after the data is prepared this is mapped through the data to get


### PR DESCRIPTION
The implementation of `filterSelected` was causing performance issues with large datasets.  

`filterSelected` was introduced as part of the fix for #158 but it turns out that it’s not needed for the solution to that issue. I’ve removed it here.

I‘m PR‘ing this to _dev_ with a view to releasing as part of 1.2.1.
