### PR TITLE
Issue 180 add select key listener

### DIFF
--- a/src/core/events.js
+++ b/src/core/events.js
@@ -275,8 +275,7 @@ const events = {
      */
     addSelectKeyListener()
     {
-        const refs    = this.refs;
-        const select  = refs.select;
+        const select  = this.refs.select;
 
         select.addEventListener( 'keyup', this.setSelectValue );
         select.addEventListener( 'keydown', this.setKeypress );
@@ -294,8 +293,6 @@ const events = {
             plug.className   = classes.PLUG;
             select.insertBefore( plug, firstOption );
         }
-
-        setTimeout( () => select.focus(), 0 );
     },
 
 
@@ -1413,8 +1410,6 @@ const events = {
         const classes = this.classes;
 
         utils.addClass( refs.optionsListWrapper, classes.HIDDEN );
-        this.removeSelectKeyListener();
-
         utils.removeClass( wrapper, classes.OPEN );
 
         const qsHTML = document.querySelector( 'html' );
@@ -1424,6 +1419,10 @@ const events = {
         if ( this.search )
         {
             this.fuzzySearchReset();
+        }
+        else
+        {
+            this.removeSelectKeyListener();
         }
 
         if ( !exit )
@@ -1516,8 +1515,6 @@ const events = {
      */
     toggleOpen( e, optionsList, refs )
     {
-        this.addSelectKeyListener();
-
         if ( !this.isIos || this.search || this.multipleTags === true )
         {
             const classes = this.classes;
@@ -1532,7 +1529,7 @@ const events = {
         }
 
 
-        if ( !this.multiple )
+        if ( !this.multipleTags )
         {
             const index       = refs.select.selectedIndex;
             const selectedDiv = refs.data[ index ];
@@ -1543,6 +1540,11 @@ const events = {
         if ( this.search )
         {
             setTimeout( () => refs.search.focus(), 0 );
+        }
+        else
+        {
+            this.addSelectKeyListener();
+            setTimeout( () => refs.select.focus(), 0 );
         }
 
         let optionCount = refs.data.length;

--- a/test/unit/core/eventsTest.js
+++ b/test/unit/core/eventsTest.js
@@ -3057,7 +3057,7 @@ describe( 'toggleOpen', () =>
         flounder.toggleOpen( {}, refs.optionList, refs, refs.wrapper );
 
         assert.equal( flounder.onOpen.callCount, 1 );
-        assert.equal( flounder.addSelectKeyListener.callCount, 1 );
+        assert.equal( flounder.addSelectKeyListener.callCount, 0 );
 
         assert.equal( utils.addClass.callCount, 1 );
         assert.equal( utils.removeClass.callCount, 1 );
@@ -3070,6 +3070,40 @@ describe( 'toggleOpen', () =>
             assert.equal( refs.search.focus.callCount, 1 );
             done();
         }, 100 );
+    } );
+
+    it( 'should call addSelectKeyListener when search is disabled', () =>
+    {
+        document.body.flounder  = null;
+        const flounder          = new Flounder( document.body, {
+            data    : [ 1, 2, 3 ],
+            search  : false
+        } );
+
+        const refs              = flounder.refs;
+
+        sinon.stub( flounder, 'addSelectKeyListener', noop );
+
+        flounder.toggleOpen( {}, refs.optionList, refs, refs.wrapper );
+
+        assert.equal( flounder.addSelectKeyListener.callCount, 1 );
+    } );
+
+    it( 'should not call addSelectKeyListener when search is enabled', () =>
+    {
+        document.body.flounder  = null;
+        const flounder          = new Flounder( document.body, {
+            data    : [ 1, 2, 3 ],
+            search  : true
+        } );
+
+        const refs              = flounder.refs;
+
+        sinon.stub( flounder, 'addSelectKeyListener', noop );
+
+        flounder.toggleOpen( {}, refs.optionList, refs, refs.wrapper );
+
+        assert.equal( flounder.addSelectKeyListener.callCount, 0 );
     } );
 
 

--- a/test/unit/core/eventsTest.js
+++ b/test/unit/core/eventsTest.js
@@ -3052,12 +3052,10 @@ describe( 'toggleOpen', () =>
 
         sinon.stub( refs.search, 'focus', noop );
         sinon.stub( flounder, 'onOpen', noop );
-        sinon.stub( flounder, 'addSelectKeyListener', noop );
 
         flounder.toggleOpen( {}, refs.optionList, refs, refs.wrapper );
 
         assert.equal( flounder.onOpen.callCount, 1 );
-        assert.equal( flounder.addSelectKeyListener.callCount, 0 );
 
         assert.equal( utils.addClass.callCount, 1 );
         assert.equal( utils.removeClass.callCount, 1 );


### PR DESCRIPTION
For #180:

- Don’t call `addSelectKeyListener()` if search is enabled
- Move `select.focus()` call out of `addSelectKeyListener()`