### PR TITLE
Fixes scrollTo #157

### DIFF
--- a/src/core/events.js
+++ b/src/core/events.js
@@ -1335,7 +1335,7 @@ const events = {
 
             utils.addClass( selectedOption, selectedClass );
 
-            utils.scrollTo( selectedOption );
+            utils.scrollTo( selectedOption, refs.optionsListWrapper );
         }
     },
 
@@ -1534,7 +1534,7 @@ const events = {
             const index       = refs.select.selectedIndex;
             const selectedDiv = refs.data[ index ];
 
-            utils.scrollTo( selectedDiv  );
+            utils.scrollTo( selectedDiv, refs.optionsListWrapper );
         }
 
         if ( this.search )

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -316,33 +316,38 @@ const utils = {
      *
      * checks if an option is visible and, if it is not, scrolls it into view
      *
-     * @param {DOMElement} element element to check
+     * @param {DOMElement}  element         element to check
+     * @param {DOMElement}  [scrollParent]  parent element to scroll
      *
      * @return {Void} void
      */
-    scrollTo( element )
+    scrollTo( element, scrollParent )
     {
         if ( element )
         {
-            const parent    = element.parentNode.parentNode;
-            const elHeight  = element.offsetHeight;
-            const min       = parent.scrollTop;
-            const max       = parent.scrollTop + parent.offsetHeight - elHeight;
-            const pos       = element.offsetTop;
+            const scrollElement = scrollParent || element.offsetParent;
 
-            if ( pos < min )
+            if ( scrollElement.scrollHeight > scrollElement.offsetHeight )
             {
-                parent.scrollTop = pos  - elHeight * 0.5;
-            }
-            else if ( pos > max )
-            {
-                parent.scrollTop = pos - parent.offsetHeight + elHeight * 1.5;
+                const pos        = element.offsetTop;
+                const elHeight   = element.offsetHeight;
+                const contHeight = scrollElement.offsetHeight;
+
+                const min = scrollElement.scrollTop;
+                const max = min + scrollElement.offsetHeight - elHeight;
+
+                if ( pos < min )
+                {
+                    scrollElement.scrollTop = pos;
+                }
+                else if ( pos > max )
+                {
+                    scrollElement.scrollTop = pos - ( contHeight - elHeight );
+                }
             }
         }
-        else
-        {
-            return false;
-        }
+
+        return false;
     },
 
 

--- a/test/unit/core/utilsTest.js
+++ b/test/unit/core/utilsTest.js
@@ -455,20 +455,19 @@ describe( 'scrollTo', () =>
         const element = {
             offsetHeight    : 10,
             offsetTop       : 150,
-            parentNode      : {
-                parentNode      : {
-                    scrollTop       : 7,
-                    offsetHeight    : 100
-                }
+            offsetParent    : {
+                scrollTop       : 7,
+                offsetHeight    : 100,
+                scrollHeight    : 500
             }
         };
 
         utils.scrollTo( element );
-        assert.equal( element.parentNode.parentNode.scrollTop, 65 );
+        assert.equal( element.offsetParent.scrollTop, 60 );
 
         element.offsetTop = 5;
         utils.scrollTo( element );
-        assert.equal( element.parentNode.parentNode.scrollTop, 0 );
+        assert.equal( element.offsetParent.scrollTop, 5 );
     } );
 
 


### PR DESCRIPTION
`scrollTo` was previously broken when options were nested in sections as it would attempt to scroll the wrong element.

- changed `element.parentNode.parentNode` to `element.scrollParent`
- added an extra param (`scrollParent`) to explicitly specify the parent element that should be scrolled
- slightly modified the scrolling implementation