### PR TITLE
Issue 188 redundant disabled class

### DIFF
--- a/src/core/api.js
+++ b/src/core/api.js
@@ -222,18 +222,15 @@ const api = {
 
         if ( bool )
         {
-            refs.flounder.removeEventListener( 'keydown',
+            flounder.removeEventListener( 'keydown',
                                                 this.checkFlounderKeypress );
-            refs.selected.removeEventListener( 'click', this.toggleList );
-            utils.addClass( selected, classes.DISABLED );
+            selected.removeEventListener( 'click', this.toggleList );
             utils.addClass( flounder, classes.DISABLED );
         }
         else
         {
-            refs.flounder.addEventListener( 'keydown',
-                                                this.checkFlounderKeypress );
-            refs.selected.addEventListener( 'click', this.toggleList );
-            utils.removeClass( selected, classes.DISABLED );
+            flounder.addEventListener( 'keydown', this.checkFlounderKeypress );
+            selected.addEventListener( 'click', this.toggleList );
             utils.removeClass( flounder, classes.DISABLED );
         }
     },

--- a/src/core/classes.js
+++ b/src/core/classes.js
@@ -3,7 +3,6 @@ const classes = {
     ARROW_INNER             : 'flounder__arrow--inner',
     DESCRIPTION             : 'flounder__option--description',
     DISABLED                : 'flounder__disabled',
-    DISABLED_OPTION         : 'flounder__disabled--option',
     HEADER                  : 'flounder__header',
     HIDDEN                  : 'flounder--hidden',
     HIDDEN_IOS              : 'flounder--hidden--ios',

--- a/src/styles/flounder-structure.css
+++ b/src/styles/flounder-structure.css
@@ -258,18 +258,12 @@ input:active ~ .flounder__arrow--wrapper
 }
 
 
-.flounder__disabled,
-.flounder__disabled--option
-{
-    cursor:                         auto;
-    pointer-events:                 none;
-}
-
-
 .flounder__disabled
 {
     border-color:                   #cccccc;
     color:                          #cccccc;
+    cursor:                         auto;
+    pointer-events:                 none;
 }
 
 

--- a/test/unit/core/apiTest.js
+++ b/test/unit/core/apiTest.js
@@ -270,13 +270,11 @@ describe( 'disable', () =>
         data : [ 1, 2, 3 ]
     } );
     const refs        = flounder.refs;
-    const selected    = refs.selected;
     const flounderEl  = refs.flounder;
 
     it( 'should disable flounder', () =>
     {
         flounder.disable( true );
-        assert.ok( utils.hasClass( selected, classes.DISABLED ) );
         assert.ok( utils.hasClass( flounderEl, classes.DISABLED ) );
     } );
 
@@ -284,7 +282,6 @@ describe( 'disable', () =>
     it( 'should enable flounder', () =>
     {
         flounder.disable();
-        assert.ok( !utils.hasClass( selected, classes.DISABLED ) );
         assert.ok( !utils.hasClass( flounderEl, classes.DISABLED ) );
     } );
 } );


### PR DESCRIPTION
For issue #188:
- no longer adds `classes.DISABLED` to `selectedDisplayed` div
- removes `classes.DISABLED_OPTION` and CSS rules (was not used)