### PR TITLE
GIT-155 updates the package entry point to work with npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
   - "10.5.0"
+  - "9.11.2"
+  - "8.12.0"
+  - "7.10.1"
+  - "7.0.0"
 script:
   - npm run build
 addons:

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ npm scripts
 Contributing
 ============
 
-Development of Flounder requires node '4.3.1' or higher.
+Development of Flounder requires node '7.0.0' or higher.
 
 Flounder's **branch structure** goes as follows:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Flounder.js 1.3.6
+Flounder.js 1.3.7
 =================
 
 [![Flounder build status](https://travis-ci.org/sociomantic-tsunami/flounder.svg)](https://travis-ci.org)
@@ -46,7 +46,7 @@ document.querySelector( '#vanilla--select' ).flounder.destroy()
 ```
 
 
-###Target options
+### Target options
 
 Flounder's target is quite flexible, however it will only build on the first element it finds.
 
@@ -85,7 +85,7 @@ new Flounder( 'input', configOptions );
 If flounder is fed an element that already has a flounder, it will destroy it and re initialize it with the new config options.
 
 
-###Available config options
+### Available config options
 
 ```js
 {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "flounder",
-    "version": "1.3.6",
+    "version": "1.3.7",
     "authors": [
         "Mouse Braun <mouse@knoblau.ch>",
     ],

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "dist/"
   ],
   "homepage": "https://github.com/sociomantic-tsunami/flounder",
-  "main": "./dist/flounder.js",
+  "main": "./src/core/flounder.js",
   "keywords": [
     "select2",
     "dropdown",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flounder",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "author": "Mouse Braun <mouse@knoblau.ch>",
   "description": "a native friendly dropdown menu",
   "repository": {

--- a/src/core/classes.js
+++ b/src/core/classes.js
@@ -20,7 +20,7 @@ const classes = {
     LOADING                 : 'flounder__loading',
     LOADING_FAILED          : 'flounder__loading--failed',
     MAIN                    : 'flounder',
-    MAIN_WRAPPER            : 'flounder--wrapper  flounder__input--select',
+    MAIN_WRAPPER            : 'flounder--wrapper',
     MULTIPLE_TAG_FLOUNDER   : 'flounder--multiple',
     MULTI_TAG_LIST          : 'flounder__multi--tag--list',
     MULTIPLE_SELECT_TAG     : 'flounder__multiple--select--tag',

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -8,4 +8,4 @@
  */
 
 /* globals module */
-module.exports = '1.3.6';
+module.exports = '1.3.7';


### PR DESCRIPTION
this fixes a long standing issue where flounder is unusable from `npm i flounder`.  

(btw, your slack channel is either broken or abandoned)